### PR TITLE
Fix: 422 Invalid request

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,6 +181,7 @@ func main() {
 			pullRequestReviewsEnforcementRequest.DismissalRestrictionsRequest = dismissalRestrictionsRequest
 			pullRequestReviewsEnforcementRequest.DismissStaleReviews = requiredPullRequestReviews.DismissStaleReviews
 			pullRequestReviewsEnforcementRequest.RequireCodeOwnerReviews = requiredPullRequestReviews.RequireCodeOwnerReviews
+			pullRequestReviewsEnforcementRequest.RequiredApprovingReviewCount = requiredPullRequestReviews.RequiredApprovingReviewCount
 			protectionRequest.RequiredPullRequestReviews = pullRequestReviewsEnforcementRequest
 		}
 


### PR DESCRIPTION
It's going to fix the error that will encounter if `Require pull request reviews before merging` is already enabled:
```plain
2020/05/05 09:27:58 PUT https://api.github.com/repos/:owner/:repo/branches/:branch/protection: 422 Invalid request.
No subschema in "anyOf" matched.
0 must be greater than or equal to 1.
Not all subschemas of "allOf" matched.
For 'anyOf/1', {"dismissal_restrictions"=>{"users"=>[], "teams"=>[]}, "dismiss_stale_reviews"=>false, "require_code_owner_reviews"=>false, "required_approving_review_count"=>0} is not a null. []
```
because `required_approving_review_count` must be greater than 0 if this rule is enabled and with current code we are always forcing a zero value which in case of `int` type is 0, by making this change we're going to get the current value and just pass it as parameter.
![Flameshot-2020-05-06_01-58-30](https://user-images.githubusercontent.com/1824874/81126987-30a33200-8f3d-11ea-9283-beb44f90e712.png)
