### PR TITLE
Reuse default transport that handles proxy configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,15 +13,21 @@ import (
 	"golang.org/x/net/context"
 )
 
+func newRoundTripper(accessToken string, insecure bool) http.RoundTripper {
+	// Reuse default transport that has timeouts and supports proxies
+	transport := http.DefaultTransport.(*http.Transport)
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+	return &roundTripper{accessToken, transport}
+}
+
 type roundTripper struct {
 	accessToken string
-	insecure    bool
+	underlying  http.RoundTripper
 }
 
 func (rt roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Set("Authorization", fmt.Sprintf("token %s", rt.accessToken))
-	transport := http.Transport {TLSClientConfig: &tls.Config{InsecureSkipVerify: rt.insecure}}
-	return transport.RoundTrip(r)
+	return rt.underlying.RoundTrip(r)
 }
 
 func isValidState(state string) bool {
@@ -99,7 +105,7 @@ func main() {
 		log.Fatal("-repo or GITHUB_REPO required")
 	}
 
-	http.DefaultClient.Transport = roundTripper{*token, *insecure}
+	http.DefaultClient.Transport = newRoundTripper(*token, *insecure)
 	var githubClient *github.Client
 	if *baseURL != "" || *uploadURL != "" {
 		if *baseURL == "" {


### PR DESCRIPTION
Currently you cannot use the application even if the proxy is correctly configured in the environment.

I am blocked on this, so if approved, I'd appreciate a swift release :)